### PR TITLE
build: Respect installation prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -28,8 +28,8 @@ add_project_link_arguments(['-rdynamic'], language:'cpp')
 
 
 ######################### Finish ###########################
-install_data('wf-prop', install_dir: '/usr/bin/')
-install_data('org.wayland.compositor.dbus.gschema.xml', install_dir: '/usr/share/glib-2.0/schemas/')
+install_data('wf-prop', install_dir: join_paths(get_option('prefix'), 'bin'))
+install_data('org.wayland.compositor.dbus.gschema.xml', install_dir: join_paths(get_option('prefix'), 'share/glib-2.0/schemas'))
 
 
 pms = shared_module('dbus_interface', 'dbus_interface.cpp',

--- a/meson.build
+++ b/meson.build
@@ -28,9 +28,18 @@ add_project_link_arguments(['-rdynamic'], language:'cpp')
 
 
 ######################### Finish ###########################
+schemas_dir = join_paths(get_option('prefix'), 'share/glib-2.0/schemas')
 install_data('wf-prop', install_dir: join_paths(get_option('prefix'), 'bin'))
-install_data('org.wayland.compositor.dbus.gschema.xml', install_dir: join_paths(get_option('prefix'), 'share/glib-2.0/schemas'))
+install_data('org.wayland.compositor.dbus.gschema.xml', install_dir: schemas_dir)
 
+r = run_command('glib-compile-schemas', schemas_dir)
+if r.returncode() == 0
+    message('\'glib-compile-schemas ' + schemas_dir + '\' succeeded')
+else
+    message(r.stdout().strip())
+    message(r.stderr().strip())
+    message('\'glib-compile-schemas ' + schemas_dir + '\' failed')
+endif
 
 pms = shared_module('dbus_interface', 'dbus_interface.cpp',
     dependencies: [wayfire, wlroots, gio, xcb, xcbres],


### PR DESCRIPTION
This allows the plugin to be installed to a nonstandard prefix as user.
XDG_DATA_DIRS should be set to contain /share.