### PR TITLE
Expand installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ Authors: Damian Ivanov
 Contributors: https://github.com/damianatorrpm/wayfire-plugin_dbus_interface/graphs/contributors
 
 ### Installation
-Standard:
-meson build && ninja -C build && meson install -C build
+- Install (wayfire-plugins-extra)[https://github.com/WayfireWM/wayfire-plugins-extra]
+- Build & install the plugin and wf-prop: `meson build && ninja -C build && sudo meson install -C build`
+- Enable `glib-main-loop` and `dbus_interface` in your wayfire.ini
+
+If one of the plugins isn't loaded (check wayfire's debug output), make sure the plugin was installed to the correct path.
 
 ### Coding style
 * uncrustify.ini in the repo


### PR DESCRIPTION
Based on IRC conversation: 
```
<soreau> solarkraft: well there was a change to dbus and I think it needs gdbus loaded too?
<soreau> hang on
<soreau> you need latest w-p-e with https://github.com/WayfireWM/wayfire-plugins-extra/blob/master/src/glib-main-loop.cpp loaded
<soreau> glib-main-loop
<soreau> then run `wayfire -d` and make sure it shows that the plugins were loaded successfully
<soreau> then you should have a binary, `wf-prop`, you can run to click on a window and get its info
<soreau> tux_: is it correct, latest dbus_interface plugin requires "glib-main-loop" to be loaded?
```
(...)
```
<tux_> soreaau: yes correct it need glib-main-loop
```

And my own experience getting it to run.